### PR TITLE
feat: ring abstraction

### DIFF
--- a/src/algebra.mbt
+++ b/src/algebra.mbt
@@ -7,9 +7,8 @@ trait Semiring {
 }
 
 ///|
-trait Inverse {
+trait Ring: Semiring {
   op_neg(Self) -> Self
-  op_sub(Self, Self) -> Self
 }
 
 ///|

--- a/src/dense_poly.mbt
+++ b/src/dense_poly.mbt
@@ -98,26 +98,16 @@ impl[A : Eq + Semiring] Semiring for Polynomial[A] with op_add(xs, ys) {
   }
 }
 
-///|
-impl[A : Inverse] Inverse for Polynomial[A] with op_sub(x, y) {
-  let lx = x.terms.length()
-  let ly = y.terms.length()
-  let l_max = @math.maximum(lx, ly)
-  let l_min = @math.minimum(lx, ly)
-  let larger = if ly >= lx { y } else { x }
-  {
-    terms: Array::makei(l_max, fn(i) {
-      if i < l_min {
-        x.terms[i] - y.terms[i]
-      } else {
-        -larger.terms[i]
-      }
-    }),
-  }
+///| 
+pub fn op_sub[A : Eq + Ring](
+  self : Polynomial[A],
+  other : Polynomial[A]
+) -> Polynomial[A] {
+  self + -other
 }
 
 ///|
-impl[A : Inverse] Inverse for Polynomial[A] with op_neg(x) {
+impl[A : Ring] Ring for Polynomial[A] with op_neg(x) {
   { terms: Array::makei(x.terms.length(), fn(i) { -x.terms[i] }) }
 }
 

--- a/src/karatsuba.mbt
+++ b/src/karatsuba.mbt
@@ -2,7 +2,7 @@
 let threshold : Int = 32
 
 ///| Multiply two polynomials using the Karatsuba algorithm.
-pub fn karatsuba[A : Eq + Semiring + Inverse](
+pub fn karatsuba[A : Eq + Semiring + Ring](
   self : Polynomial[A],
   other : Polynomial[A]
 ) -> Polynomial[A] {
@@ -52,7 +52,7 @@ pub fn karatsuba[A : Eq + Semiring + Inverse](
         } else {
           A::zero()
         }
-        zs.terms[k] = z0 + (z11 - (z10 + z12)) + z2
+        zs.terms[k] = z0 + (z11 + -(z10 + z12)) + z2
       }
       zs
     }


### PR DESCRIPTION
- Add `Ring` as a sub-class of `Semiring`.
- `op_sub` was removed because it can be derived from `op_neg` and `op_add`.